### PR TITLE
Fix page transitions

### DIFF
--- a/packages/kit-docs/src/lib/components/layout/OnThisPage.svelte
+++ b/packages/kit-docs/src/lib/components/layout/OnThisPage.svelte
@@ -15,7 +15,7 @@
   export let style = '';
 </script>
 
-{#if $kitDocs.meta.hasHeaders}
+{#if $kitDocs.meta?.hasHeaders}
   <div class={clsx('on-this-page', __class)} {style}>
     <h5 class="font-semibold w-full text-left text-gray-inverse text-lg">On this page</h5>
     <ul class="space-y-4 mt-4">


### PR DESCRIPTION
```svelte
{#key meta?.title}
  <div in:fly={enter} out:fly={leave}>
    <slot />
  </div>
{/key}
```


Currently, when trying to implement page transitions like this, you will get the following error:
```
OnThisPage.svelte? [sm]:12 Uncaught (in promise) TypeError: Cannot read properties of null (reading 'meta')
    at Object.update [as p] (:3000/node_modules/.pnpm/@svelteness+kit-docs@0.3.3_2e7f980614ba19fa3010d74a9a55b714/node_modules/@svelteness/kit-docs/client/components/layout/OnThisPage.svelte:535:28)
    at update (:3000/node_modules/.vite/deps/chunk-7B36NNJA.js?v=c8e5114e:964:32)
    at flush (:3000/node_modules/.vite/deps/chunk-7B36NNJA.js?v=c8e5114e:935:7)
```

With optional chaining, this error no longer occurs, and Svelte transitions work just fine.