### PR TITLE
Fix documentation

### DIFF
--- a/packages/kit-docs/src/routes/docs/[...2]default-layout/[...2]configuration.md
+++ b/packages/kit-docs/src/routes/docs/[...2]default-layout/[...2]configuration.md
@@ -176,11 +176,13 @@ The config above will be resolved to this:
 
 ```js
 const sidebar = {
-  'First Category': [
-    { title: 'First Page', slug: '/docs/first-category/first-page' },
-    { title: 'Second Page', slug: '/docs/second-category/second-page' },
-  ],
-  'Second Category': [],
+  links: {
+    'First Category': [
+      { title: 'First Page', slug: '/docs/first-category/first-page' },
+      { title: 'Second Page', slug: '/docs/second-category/second-page' },
+    ],
+    'Second Category': [],
+  }
 };
 ```
 


### PR DESCRIPTION
It seems like you missed the `links` property in the sample to show the resolved code (https://kit-docs.svelteness.dev/docs/default-layout/configuration#simple-links):

```js
const sidebar = {
  links: {
    'First Category': [
      { title: 'First Page', slug: '/docs/first-category/first-page' },
      { title: 'Second Page', slug: '/docs/second-category/second-page' },
    ],
    'Second Category': [],
  }
};
```

instead of

```js
const sidebar = {
  'First Category': [
    { title: 'First Page', slug: '/docs/first-category/first-page' },
    { title: 'Second Page', slug: '/docs/second-category/second-page' },
  ],
  'Second Category': [],
};
```