### PR TITLE
Fix outdated Github links

### DIFF
--- a/packages/kit-docs/src/routes/docs/[...1]getting-started/[...2]quickstart.md
+++ b/packages/kit-docs/src/routes/docs/[...1]getting-started/[...2]quickstart.md
@@ -262,10 +262,10 @@ module.exports = {
 };
 ```
 
-Finally, copy and adjust our [theme](https://github.com/svelteness/kit-docs/blob/main/kit-docs/tailwind.config.cjs#L14-L51)
-and [variants plugin](https://github.com/svelteness/kit-docs/blob/main/kit-docs/tailwind.config.cjs#L64-L77)
+Finally, copy and adjust our [theme](https://github.com/svelteness/kit-docs/blob/main/packages/kit-docs/tailwind.config.cjs#L14-L51)
+and [variants plugin](https://github.com/svelteness/kit-docs/blob/main/packages/kit-docs/tailwind.config.cjs#L64-L77)
 settings into your `tailwind.config.cjs` file. Refer to our
-[CSS variables file](https://github.com/svelteness/kit-docs/blob/main/kit-docs/src/lib/styles/vars.css)
+[CSS variables file](https://github.com/svelteness/kit-docs/blob/main/packages/kit-docs/src/lib/styles/vars.css)
 to get any values.
 
 ## Meta Endpoint

--- a/packages/kit-docs/src/routes/docs/[...2]default-layout/[...1]installation.md
+++ b/packages/kit-docs/src/routes/docs/[...2]default-layout/[...1]installation.md
@@ -118,5 +118,5 @@ module.exports = {
 };
 ```
 
-3. Finally, copy over our [Tailwind config](https://github.com/svelteness/kit-docs/blob/main/kit-docs/tailwind.config.cjs)
+3. Finally, copy over our [Tailwind config](https://github.com/svelteness/kit-docs/blob/main/packages/kit-docs/tailwind.config.cjs)
    file from GitHub and adjust values as desired. Ignore the `corePlugins` and `fontFamily` settings.

--- a/packages/kit-docs/src/routes/docs/[...2]default-layout/[...2]configuration.md
+++ b/packages/kit-docs/src/routes/docs/[...2]default-layout/[...2]configuration.md
@@ -32,7 +32,7 @@ your own like so:
 rm -rf src/fonts
 ```
 
-2. Finally, load your own fonts (see our [fonts file](https://github.com/svelteness/kit-docs/blob/main/kit-docs/src/lib/styles/fonts.css)
+2. Finally, load your own fonts (see our [fonts file](https://github.com/svelteness/kit-docs/blob/main/packages/kit-docs/src/lib/styles/fonts.css)
    for reference) and set the font family CSS variables like so:
 
 ```html


### PR DESCRIPTION
Current URLs from the documentation link to 404 page