### PR TITLE
fix: pin create-svelte version to avoid bug like #52

### DIFF
--- a/packages/create-kit-docs/bin/create-kit-docs.js
+++ b/packages/create-kit-docs/bin/create-kit-docs.js
@@ -37,7 +37,7 @@ async function main() {
     console.log(`\n[kit-docs]: target directory is empty, creating new SvelteKit app.\n`);
 
     try {
-      const child = spawn('npm', ['create', 'svelte', rootDirName ?? '.'], {
+      const child = spawn('npm', ['create', 'svelte@2.0.0-next.147', rootDirName ?? '.'], {
         stdio: 'inherit',
         shell: true,
       });


### PR DESCRIPTION
See https://github.com/svelteness/kit-docs/issues/52#issuecomment-1186494202

@mihar-22 what do you think about this Pull Request, to pin [`create-svelte`](https://github.com/sveltejs/kit/blob/0dd17945445661f04d11863ff0650910c1448248/packages/create-svelte/package.json#L3) version to avoid SvelteKit breaking changes.