### PR TITLE
fix: upgrade @sveltejs/kit from 1.0.0-next.370 to 1.0.0-next.371 #59

### DIFF
--- a/demo/package.json
+++ b/demo/package.json
@@ -14,7 +14,7 @@
     "@iconify-json/ri": "^1.1.1",
     "@sveltejs/adapter-auto": "1.0.0-next.57",
     "@sveltejs/adapter-static": "1.0.0-next.35",
-    "@sveltejs/kit": "1.0.0-next.370",
+    "@sveltejs/kit": "1.0.0-next.371",
     "@svelteness/kit-docs": "workspace:*",
     "shiki": "^0.10.1",
     "svelte": "^3.44.0",

--- a/packages/create-kit-docs/bin/create-kit-docs.js
+++ b/packages/create-kit-docs/bin/create-kit-docs.js
@@ -105,7 +105,7 @@ async function main() {
   const deps = {
     '@iconify-json/ri': '^1.1.1',
     '@sveltejs/adapter-auto': '^1.0.0-next.57',
-    '@sveltejs/kit': '^1.0.0-next.370',
+    '@sveltejs/kit': '^1.0.0-next.371',
     '@svelteness/kit-docs': `^${version}`,
     clsx: '^1.1.0',
     'unplugin-icons': '^0.13.0',

--- a/packages/kit-docs/package.json
+++ b/packages/kit-docs/package.json
@@ -74,7 +74,7 @@
     "@rollup/pluginutils": "^4.2.0",
     "@sveltejs/adapter-auto": "1.0.0-next.57",
     "@sveltejs/adapter-static": "1.0.0-next.35",
-    "@sveltejs/kit": "1.0.0-next.370",
+    "@sveltejs/kit": "1.0.0-next.371",
     "@svelteness/kit-docs": "link:.",
     "@tailwindcss/typography": "^0.5.2",
     "@types/react": "^17.0.39",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -63,7 +63,7 @@ importers:
       '@iconify-json/ri': ^1.1.1
       '@sveltejs/adapter-auto': 1.0.0-next.57
       '@sveltejs/adapter-static': 1.0.0-next.35
-      '@sveltejs/kit': 1.0.0-next.370
+      '@sveltejs/kit': 1.0.0-next.371
       '@svelteness/kit-docs': workspace:*
       clsx: ^1.1.1
       shiki: ^0.10.1
@@ -80,7 +80,7 @@ importers:
       '@iconify-json/ri': 1.1.3
       '@sveltejs/adapter-auto': 1.0.0-next.57
       '@sveltejs/adapter-static': 1.0.0-next.35
-      '@sveltejs/kit': 1.0.0-next.370_svelte@3.49.0+vite@2.9.14
+      '@sveltejs/kit': 1.0.0-next.371_svelte@3.49.0+vite@2.9.14
       '@svelteness/kit-docs': link:../packages/kit-docs
       shiki: 0.10.1
       svelte: 3.49.0
@@ -116,7 +116,7 @@ importers:
       '@rollup/pluginutils': ^4.2.0
       '@sveltejs/adapter-auto': 1.0.0-next.57
       '@sveltejs/adapter-static': 1.0.0-next.35
-      '@sveltejs/kit': 1.0.0-next.370
+      '@sveltejs/kit': 1.0.0-next.371
       '@svelteness/kit-docs': link:.
       '@tailwindcss/typography': ^0.5.2
       '@types/lru-cache': ^7.4.0
@@ -168,7 +168,7 @@ importers:
       '@rollup/pluginutils': 4.2.1
       '@sveltejs/adapter-auto': 1.0.0-next.57
       '@sveltejs/adapter-static': 1.0.0-next.35
-      '@sveltejs/kit': 1.0.0-next.370_svelte@3.49.0+vite@2.9.14
+      '@sveltejs/kit': 1.0.0-next.371_svelte@3.49.0+vite@2.9.14
       '@svelteness/kit-docs': 'link:'
       '@tailwindcss/typography': 0.5.4_tailwindcss@3.1.6
       '@types/react': 17.0.47
@@ -632,8 +632,8 @@ packages:
       - supports-color
     dev: true
 
-  /@sveltejs/kit/1.0.0-next.370_svelte@3.49.0+vite@2.9.14:
-    resolution: {integrity: sha512-HAQtw8IjXs9yOPWKpuwpGgDT8x6Dgqm14NmFx0emF52vo5wn3tQzu0cBx299Po2RdRgfSDFKrNqVSlL1hVTHcA==}
+  /@sveltejs/kit/1.0.0-next.371_svelte@3.49.0+vite@2.9.14:
+    resolution: {integrity: sha512-2MXNb0M97lsEbJx167YNb6ofGRNuNEBUJM9ntIce6usWaurh+2mMg185sA4p0Kl7gl9xSM2D9GXGT7mlaEmJGA==}
     engines: {node: '>=16.9'}
     hasBin: true
     peerDependencies:


### PR DESCRIPTION
To fix "Function called outside component initialization error".

SvelteKit issue https://github.com/sveltejs/kit/issues/5495