### PR TITLE
fix: Vite server repeatedly restarting (#70)

### DIFF
--- a/packages/kit-docs/vite.config.js
+++ b/packages/kit-docs/vite.config.js
@@ -12,6 +12,9 @@ const config = {
   },
 
   server: {
+    watch: {
+      usePolling: true,
+    },
     fs: {
       strict: false,
     },


### PR DESCRIPTION
This still needs to be root caused because I have no idea why this is needed but I'm not sure where to start.
This change works reliably for me and gets this lib into a usable state with recent versions of Svelte.