### PR TITLE
fix: add code block support for multiple languages

### DIFF
--- a/packages/kit-docs/src/node/markdown-plugin/parser/plugins/shiki-plugin.ts
+++ b/packages/kit-docs/src/node/markdown-plugin/parser/plugins/shiki-plugin.ts
@@ -1,10 +1,29 @@
-import { type PluginSimple } from 'markdown-it';
-import { type HighlighterOptions, getHighlighter, renderToHtml } from 'shiki';
+import {type PluginSimple} from 'markdown-it';
+import {type HighlighterOptions, getHighlighter, renderToHtml} from 'shiki';
 
 export const createShikiPlugin = async (options?: HighlighterOptions) => {
   const highlighter = await getHighlighter({
     theme: 'material-palenight',
-    langs: ["bash", "javascript", "typescript", "svelte", "markdown", "html", "diff", "css", "json", "toml"],
+    langs: [
+      "bash",
+      "css",
+      "diff",
+      "docker",
+      "graphql",
+      "html",
+      "javascript",
+      "json",
+      "jsx",
+      "markdown",
+      "python",
+      "rust",
+      "sql",
+      "svelte",
+      "toml",
+      "tsx",
+      "typescript",
+      "yaml",
+    ],
     ...options,
   });
 


### PR DESCRIPTION
Added support for Python and other languages in response to issue #89.
Other languages added:
- docker
- graphql
- jsx
- rust
- sql
- tsx
- yaml

I was able to run tests on the project I was using, and the code blocks work for each language added and any old languages that were supported previously.