### PR TITLE
Allow docs / sidebar from root

### DIFF
--- a/packages/kit-docs/src/lib/loaders/index.ts
+++ b/packages/kit-docs/src/lib/loaders/index.ts
@@ -53,10 +53,10 @@ export async function loadKitDocsSidebar(
 ): Promise<ResolvedSidebarConfig | null> {
   const matchedPath = matchSidebarPath(event.url, path);
 
-  if (!matchedPath) return null;
+  if (matchedPath === null) return null;
 
   try {
-    const res = await event.fetch(`${base}/kit-docs/${slugToRequestParam(matchedPath)}.sidebar`);
+    const res = await event.fetch(`${base}/kit-docs/${matchedPath === '' ? 'index' : slugToRequestParam(matchedPath)}.sidebar`);
     return res.json();
   } catch (e) {
     return null;

--- a/packages/kit-docs/src/node/handlers/index.ts
+++ b/packages/kit-docs/src/node/handlers/index.ts
@@ -183,7 +183,7 @@ export async function handleSidebarRequest(
     exts.length > 1 ? `.{${exts.map((ext) => ext.replace(/^\./, '')).join(',')}}` : exts[0];
 
   const directory = paramToDir(dirParam);
-  const dirPath = path.resolve(ROUTES_DIR, directory);
+  const dirPath = path.resolve(ROUTES_DIR, directory === 'index' ? '' : directory);
 
   const filePaths = sortOrderedFiles(readDirDeepSync(dirPath));
 


### PR DESCRIPTION
Enables docs to be in the root of the site instead of nested in any subfolder (`/docs` in the example). [Example](https://captaincodeman.github.io/svelte-headlessui/) of where this would be useful (to keep existing URLs).

The layout.js page would change to return an empty string for the root path:

```ts
export const load = createKitDocsLoader({
  sidebar: {
    '/': '',
  },
});
```

Other references to `/docs` would be removed, page.js for example:

```ts
export function load() {
  throw redirect(307, '/getting-started/introduction');
}
```

I used 'index' to represent the root when the sidebar is requested which was also used for the root _meta_ request - it's _possible_ this could interfere with someone having a docs folder called `/index` so might benefit from changing to some special character (such as `~`). Another alternative might be to make the route param optional (`/[[dir]].sidebar/+server.js`) instead.